### PR TITLE
Keep temporary view matrix alive

### DIFF
--- a/src/OVRWindow.cpp
+++ b/src/OVRWindow.cpp
@@ -850,11 +850,11 @@ OVRWindow::getFrameRenderContext(const ovrEyeType& eye, const ovrPosef& pose)
    const auto& viewAdjust = renderInfo.ViewAdjust;
 
    // Calculate the view matrix.
-   const auto* V = &
-   (
-      OVR::Matrix4f::Translation(viewAdjust) *
-      OVR::Matrix4f(OVR::Quatf(pose.Orientation).Inverted())
-   ).M[0][0];
+   const auto& viewMatrix = (
+               OVR::Matrix4f::Translation(viewAdjust) *
+               OVR::Matrix4f(OVR::Quatf(pose.Orientation).Inverted())
+               );
+   const auto* V = &viewMatrix.M[0][0];
    for (unsigned int i = 0; i < 4; ++i)
    {
       auto& view = frameRenderContext.view;


### PR DESCRIPTION
`V` was just a reference on temporary matrix object. To be sure object is alive let's hold a matrix reference while `V` pointer is alive.

Signed-off-by: Anton Sergunov anton@ahead.io
